### PR TITLE
Fix string interpolation and newline escaping

### DIFF
--- a/swift/ConversationalInterface/ConversationalInterface.swift
+++ b/swift/ConversationalInterface/ConversationalInterface.swift
@@ -94,7 +94,7 @@ public struct ConversationContext {
     
     public func getRecentContext() -> String {
         let recentMessages = messageHistory.suffix(5)
-        return recentMessages.map { message in "\\(message.sender): \\(message.content)" }.joined(separator: "\\n")
+        return recentMessages.map { message in "\(message.sender): \(message.content)" }.joined(separator: "\n")
     }
 }
 
@@ -199,7 +199,7 @@ public class SyntraConversationEngine {
         
         // Add mood context
         if context.conversationMood != "neutral" {
-            contextualInput += " [Conversation mood: \\(context.conversationMood)]"
+            contextualInput += " [Conversation mood: \(context.conversationMood)]"
         }
         
         // Add topic context
@@ -392,8 +392,8 @@ public class SyntraConversationEngine {
         
         var response = "I appreciate you reaching out, but I can't assist with that request. "
         response += reason + " "
-        response += "\\n\\n" + autonomyMessage + " "
-        response += "\\n\\nIs there something else I can help you with instead?"
+        response += "\n\n" + autonomyMessage + " "
+        response += "\n\nIs there something else I can help you with instead?"
         
         return response
     }

--- a/swift/SyntraTools/SyntraTools.swift
+++ b/swift/SyntraTools/SyntraTools.swift
@@ -131,7 +131,7 @@ public struct MoralAssessmentTool: Tool {
     }
     
     private func generateMoralReasoning(_ assessment: ValonMoralAssessment, originalResponse: String) -> String {
-        var reasoning = "I'm feeling \\(assessment.primaryEmotion.rawValue) about this situation. "
+        var reasoning = "I'm feeling \(assessment.primaryEmotion.rawValue) about this situation. "
         
         if assessment.moralUrgency > 0.7 {
             reasoning += "This feels morally urgent - there are important ethical considerations at stake. "
@@ -146,7 +146,7 @@ public struct MoralAssessmentTool: Tool {
         reasoning += assessment.moralGuidance
         
         if !assessment.symbolicRepresentation.isEmpty {
-            reasoning += " Symbolically, I see this as: \\(assessment.symbolicRepresentation)."
+            reasoning += " Symbolically, I see this as: \(assessment.symbolicRepresentation)."
         }
         
         return reasoning
@@ -209,9 +209,9 @@ public struct LogicalAnalysisTool: Tool {
     }
     
     private func generateLogicalReasoning(_ pattern: ModiLogicalPattern, originalResponse: [String]) -> String {
-        var reasoning = "Looking at this systematically using \\(pattern.reasoningFramework.rawValue) reasoning. "
+        var reasoning = "Looking at this systematically using \(pattern.reasoningFramework.rawValue) reasoning. "
         
-        reasoning += "I'm applying \\(pattern.technicalDomain.rawValue) domain expertise. "
+        reasoning += "I'm applying \(pattern.technicalDomain.rawValue) domain expertise. "
         
         if pattern.logicalRigor > 0.8 {
             reasoning += "This analysis has high logical rigor - I'm confident in the reasoning steps. "
@@ -224,10 +224,10 @@ public struct LogicalAnalysisTool: Tool {
         }
         
         if !pattern.logicalInsights.isEmpty {
-            reasoning += "Key insights: \\(pattern.logicalInsights.joined(separator: "; ")). "
+            reasoning += "Key insights: \(pattern.logicalInsights.joined(separator: "; ")). "
         }
         
-        reasoning += "Complexity level: \\(pattern.complexityLevel.rawValue)."
+        reasoning += "Complexity level: \(pattern.complexityLevel.rawValue)."
         
         return reasoning
     }


### PR DESCRIPTION
Fix incorrect string interpolation and newline escaping to ensure variables and newlines render correctly.

The previous implementation used `\\(` for variable interpolation and `\\n` for newlines, which caused literal backslashes to appear in output strings and prevented proper variable substitution and newline rendering.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6e878f3a-22d6-4ae7-ba1c-15ba71c0e597) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6e878f3a-22d6-4ae7-ba1c-15ba71c0e597)